### PR TITLE
Open up dependencies to allow Omniauth 2.X

### DIFF
--- a/lib/omniauth/snapchat/version.rb
+++ b/lib/omniauth/snapchat/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module Snapchat
-    VERSION = "0.1.1"
+    VERSION = "0.1.2"
   end
 end

--- a/omniauth-snapchat.gemspec
+++ b/omniauth-snapchat.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files`.split("\n")
 
   spec.add_development_dependency "bundler", "~> 1.16"
-  spec.add_runtime_dependency "omniauth", "~> 1.2"
+  spec.add_runtime_dependency "omniauth", ">=1.2", '< 3.0'
   spec.add_runtime_dependency "omniauth-oauth2", "~> 1.1"
 end


### PR DESCRIPTION
### Related Issue(s)
https://github.com/Loomly/calendy/issues/11353

### Brief Summary of Issue
Updates needed for security and functionality require all omniauth strategies to operate with omniauth 2.X

### Details about Solution Chosen
This optimistically opens this gem to allow Omniauth 2.x but nothing 3.X or higher

### How & What to Test
With an ingesting repo (i.e. Calendy), utilized the new version of the gem and verified functionality of the snapchat Oauth connection. I Compared authorization data capture both before and after upgrading the gem version with no meaningful differences noted.

### Unrelated Components Potentially Affected by Changes
N/A